### PR TITLE
fix: get solana price

### DIFF
--- a/src/fetchClmmPosition.js
+++ b/src/fetchClmmPosition.js
@@ -1,4 +1,4 @@
-import { RAYDIUM_IPFS_GATEWAY } from "./config";
+import { RAYDIUM_IPFS_GATEWAY } from "./config.js";
 
 /**
  *

--- a/src/getLiq.js
+++ b/src/getLiq.js
@@ -14,6 +14,7 @@ export async function getLiq() {
   const uniqueTokenAddresses = new Set([
     ...LpPositions.flatMap(position => [position.mintA.address, position.mintB.address]),
     ...nonLpTokenAccounts.map(({ account }) => account.data.parsed.info.mint),
+    SOLANA_TOKEN_ADDRESS,
   ]);
   const priceMap = await getLlamaPrices([...uniqueTokenAddresses]);
 

--- a/src/getTokenAccounts.js
+++ b/src/getTokenAccounts.js
@@ -1,5 +1,5 @@
 import { Connection, PublicKey } from "@solana/web3.js";
-import { SOL_WALLET_ADDRESS, SOLANA_RPC_ENDPOINT, TOKEN_2022_PROGRAM_ID } from "./config";
+import { SOL_WALLET_ADDRESS, SOLANA_RPC_ENDPOINT, TOKEN_2022_PROGRAM_ID } from "./config.js";
 
 /**
  * Fetches token accounts


### PR DESCRIPTION
when no LP tokens with WSOL, Solana token address wasn't added to set of addresses to fetch prices for; manually added it